### PR TITLE
Action tag @SURVEY-DURATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ This module provides end users with the ability to apply certain survey tweaks e
  the initial data entry.  To use, have a non-login survey where they enter their 'code'.  Set this survey as the
   EM option.  Then, when it is saved, it will automatically make the cookies as though the user just logged in.
 
+1. **Survey Duration Fields:** Designate text fields for capture of the cumulative duration that a survey respondent spends on the survey page where the field is located. Fields can be designated either via the project module configuration dialog or by specifing the action tag @SURVEY-DURATION in Field Annotations.
+
 What's next?  Up to you.  Post an issue as a request on the github site or fork and make a pull request on your own.

--- a/SurveyUITweaks.php
+++ b/SurveyUITweaks.php
@@ -145,6 +145,13 @@ class SurveyUITweaks extends \ExternalModules\AbstractExternalModule
             $duration_fields[] = $setting['duration_field'];
         }
 
+        $metadata = REDCap::getDataDictionary('array',false,null,$instrument,false);
+        foreach ($metadata as $field_name=>$field_attributes) {
+            if (!in_array($field_name, $duration_fields) && preg_match('/@SURVEY-?DURATION(?=\s|$)/', $field_attributes['field_annotation'])) {
+                $duration_fields[] = $field_name;
+            }
+        }
+
         // Dont do anything if we don't have any duration fields specified
         if (empty($duration_fields)) return false;
 

--- a/config.json
+++ b/config.json
@@ -11,8 +11,7 @@
 			"0.2": "Added global function",
 			"1.0.0": "initial repo release",
 			"1.0.1": "changed class so as not to have array constants",
-			"1.1.5": "fixed matrix ranking bug",
-			"1.2.0": "added @SURVEY-DURATION action tag for survey duration"
+			"1.1.5": "fixed matrix ranking bug"
 		}
 	],
 

--- a/config.json
+++ b/config.json
@@ -11,7 +11,8 @@
 			"0.2": "Added global function",
 			"1.0.0": "initial repo release",
 			"1.0.1": "changed class so as not to have array constants",
-			"1.1.5": "fixed matrix ranking bug"
+			"1.1.5": "fixed matrix ranking bug",
+			"1.2.0": "added @SURVEY-DURATION action tag for survey duration"
 		}
 	],
 


### PR DESCRIPTION
Survey page duration fields can now be designated via the action tag @SURVEY-DURATION in addition to via the module config dialog.