### PR TITLE
Modifications to save and return later button/emailing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This module provides end users with the ability to apply certain survey tweaks e
 
 1. **Save and Return without email:** Remove the option to send a return link to the user's email. Users must save the url themselves.
 
+1. **Save and Return Later button:** Remove the 'Save and Return Later' button. Users must save the url themselves.
+
 1. **Survey Login on Save** You can use this feature to prevent users from having to perform a survey-login during
  the initial data entry.  To use, have a non-login survey where they enter their 'code'.  Set this survey as the
   EM option.  Then, when it is saved, it will automatically make the cookies as though the user just logged in.

--- a/SurveyUITweaks.php
+++ b/SurveyUITweaks.php
@@ -98,7 +98,8 @@ class SurveyUITweaks extends \ExternalModules\AbstractExternalModule
             'hide_required_text'            => 'hideRequiredText',
             'resize_survey'                 => 'resizeSurvey',
             'social_share'                  => 'socialShare',
-            'responsive_td_fix'             => 'customTDFix'
+            'responsive_td_fix'             => 'customTDFix',
+            'save_and_return_later_button'  => 'saveAndReturnLaterButton'
         );
 
         foreach($survey_page_top_tweaks as $key=>$func) {
@@ -685,6 +686,17 @@ class SurveyUITweaks extends \ExternalModules\AbstractExternalModule
         <?php
     }
 
+    function saveAndReturnLaterButton()
+    {
+        ?>
+        <script type = "text/javascript">
+            $(document).ready(function(){
+                $("button[name='submit-btn-savereturnlater']").closest('tr').hide();
+            });
+        </script>
+        <?php
+    }
+
     function saveAndReturnWithoutEmail()
     {
         ?>
@@ -692,6 +704,10 @@ class SurveyUITweaks extends \ExternalModules\AbstractExternalModule
             #return_instructions {display:none;}
         </style>
         <script type = "text/javascript">
+            function emailReturning() {
+                $("span[data-rc-lang='survey_582']").closest('div').remove();
+            }
+
             $(document).ready(function(){
                 $(document.querySelector("#return_instructions > div > div:nth-child(5)")).remove();
                 $(document.querySelector("#return_instructions > div > div:nth-child(4) > span:nth-child(8)")).remove();

--- a/config.json
+++ b/config.json
@@ -128,6 +128,12 @@
             "type": "checkbox"
         },
         {
+            "key": "global_save_and_return_later_button",
+            "name": "Remove the \"Save and Return Later\" button, users must have return link and code",
+            "required": false,
+            "type": "checkbox"
+        },
+        {
             "key": "global_social_share",
             "name": "Add Share (survey link) on Social Media Icons",
             "required": false,


### PR DESCRIPTION
When utilizing 'Save and Return Later' button, disable the email that is sent automatically.
Add a new second option to hide the 'Save and Return Later' button entirely.

Useful when utilizing anonymous surveys where participants are assigned a link and email is not collected among other special use-cases.